### PR TITLE
Fix getWall typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -933,7 +933,10 @@ declare module "noblox.js" {
 
     interface WallPost {
         id: number;
-        poster: GroupUser;
+        poster: {
+            user: GroupUser;
+            role: Role;
+        };
         body: string;
         created: Date;
         updated: Date;


### PR DESCRIPTION
This fixes the typings that I guess weren't updated when you guys made the switch from the v1 API to the v2 API